### PR TITLE
add flexbox growing and shrinking chapter

### DIFF
--- a/flexbox/growing_and_shrinking.html
+++ b/flexbox/growing_and_shrinking.html
@@ -23,6 +23,16 @@
       #grow {
         flex: 2 1 0%;
       }
+      .flex-container .five {
+        background: peachpuff;
+        border: 4px solid brown;
+        height: 100px;
+        width: 250px;
+        flex: 1 1 auto;
+      }
+      #shrink {
+        flex-shrink: 0;
+      }
     </style>
   </head>
     <div class="flex-container">
@@ -34,6 +44,11 @@
       <div class="four"></div>
       <div id="grow" class="four"></div>
       <div class="four"></div>
+    </div>
+    <div class="flex-container">
+      <div class="five"></div>
+      <div id="shrink" class="five"></div>
+      <div class="five"></div>
     </div>
   <body>
   </body>

--- a/flexbox/growing_and_shrinking.html
+++ b/flexbox/growing_and_shrinking.html
@@ -14,12 +14,26 @@
         height: 100px;
         flex: 1
       }
+      .flex-container .four {
+        background: peachpuff;
+        border: 4px solid brown;
+        height: 100px;
+        flex: 1
+      }
+      #grow {
+        flex: 2 1 0%;
+      }
     </style>
   </head>
     <div class="flex-container">
       <div class="one"></div>
       <div class="two"></div>
       <div class="three"></div>
+    </div>
+    <div class="flex-container">
+      <div class="four"></div>
+      <div id="grow" class="four"></div>
+      <div class="four"></div>
     </div>
   <body>
   </body>

--- a/flexbox/growing_and_shrinking.html
+++ b/flexbox/growing_and_shrinking.html
@@ -8,7 +8,7 @@
         display: flex;
       }
 
-      .flex-container div {
+      .flex-container .one,.two,.three {
         background: peachpuff;
         border: 4px solid brown;
         height: 100px;

--- a/flexbox/growing_and_shrinking.html
+++ b/flexbox/growing_and_shrinking.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Growing and Shrinking</title>
+    <style>
+      .flex-container {
+        display: flex;
+      }
+
+      .flex-container div {
+        background: peachpuff;
+        border: 4px solid brown;
+        height: 100px;
+        flex: 1
+      }
+    </style>
+  </head>
+    <div class="flex-container">
+      <div class="one"></div>
+      <div class="two"></div>
+      <div class="three"></div>
+    </div>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
As already discovered by testing in the previous chapter, the modification of the property `flex` of a flex iteam has effect on the sizing of the element. This behaviour and other specifics of this property will be discussed in this PR.

## The flex shorthand
The property `flex` used with just a single value is a shorthand. Other shorthands where used in the previous PRs for properties like `margin` order `padding` and just means, that the values are used for multiple settings of the property without specificly specifing them. For `flex` the value of 1 translatest to this code:
```
flex-grow: 1,
flex-shrink: 1,
flex-basis: 0
```
## Flex-grow
Is used to tell the growth factor of the styled element. As depicted by the tests in the previous PR, the changing of this values makes the flex item larger (or the other ones smaller) depending on the values choosen for the different items in the flex container.

## Flex-shrink
Other the flex-grow, the shrinking only accures, when the flex-container is to small to fit all the elements with their given width. Flex items will always shrink down to fit inside of theire parent. This usually happens consistently for all elements, due to the default `flex-shrink` value being 1. When this value is adjusted, the elements with a `flex-shrink` value of 0 will keep their given width and elements with a higher value will shrink faster then the other elements.
A Note from the project says:
> An important implication to notice here is that when you specify flex-grow or flex-shrink, flex items do not necessarily respect your given values for width. In the above example, all 3 divs are given a width of 250px, but when their parent is big enough, they grow to fill it. Likewise, when the parent is too small, the default behavior is for them to shrink to fit. This is not a bug, but it could be confusing behavior if you aren’t expecting it.

## Flex-basis
Sets up how the box starts out. This was usually set up 0% which will spread the space evenly between all flex-items of the flex container. When `flex-basis` has to be set to `auto`, to respect any width definition in the styling, which is the reason for it's usage in the example for `flex-shrink`.