### PR TITLE
add flexbox axes chapter

### DIFF
--- a/flexbox/axes.html
+++ b/flexbox/axes.html
@@ -4,8 +4,24 @@
     <meta charset="UTF-8">
     <title>Axes</title>
     <style>
+      .flex-container {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .flex-container div {
+        background: peachpuff;
+        border: 4px solid brown;
+        height: 80px;
+        flex: 1 1 auto;
+      }
     </style>
   </head>
   <body>
+    <div class="flex-container">
+      <div class="one"></div>
+      <div class="two"></div>
+      <div class="three"></div>
+    </div>
   </body>
 </html>

--- a/flexbox/axes.html
+++ b/flexbox/axes.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Axes</title>
+    <style>
+    </style>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
This Chapter focuses around the usage of flex with the option to align flex-items in columns. Earlier only the option to align them horizontally. This also will change the behaviours of some ot the properties used so far. It is not needed to specify the direction for horizontal alignment since this is the default for flex.

## Axes
The basic is, that the `flex-direction` changes the alignment of the flex-items inside of it. While the default value of `column` aligns the items from left to right, the value `column` aligns them from top to bottom.
Also to make the example work without content, the `flex` property of the items could not be used with only one value (shorthand) since this sets the property `flex-base` to 0, which in turn will not respect the set height for the item. This proplem was mentioned befor but for the width of the items without using `flex-direction`, which defaultet to column.

## Changed behaviour
When switching the value of `flex-direction` from `row` to `column`, the properties `flex-basis` changes it's behaviour and now refers to the height instead of the width of the item.